### PR TITLE
using sc.datasets.pbmc3k_processed() instead of on-disk adata

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See gssnng/notebooks for examples on all methods
 ```
 from gssnng import score_cells
 
-q = sc.read_h5ad('gssnng/gssnng/test/data/pbmc3k_processed.h5ad')
+q = sc.datasets.pbmc3k_processed()
 
 sc.pp.neighbors(q, n_neighbors=32)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,7 +106,7 @@ See gssnng/notebooks for examples on all methods.
 
    from gssnng import score_cells
 
-    q = sc.read_h5ad('gssnng/gssnng/test/data/pbmc3k_processed.h5ad')
+    q = sc.datasets.pbmc3k_processed()
 
     sc.pp.neighbors(q, n_neighbors=32)
 

--- a/gssnng/test/example_script.py
+++ b/gssnng/test/example_script.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         import time
 
         print("reading data")
-        q = sc.read_h5ad('data/pbmc3k_processed.h5ad')
+        q = sc.datasets.pbmc3k_processed()
 
         print("computing neighborhood")
         sc.pp.neighbors(q, n_neighbors=32)

--- a/gssnng/test/score_cells_test.py
+++ b/gssnng/test/score_cells_test.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
 
 
     def test_score_all_sets():
-        q = sc.read_h5ad('data/pbmc3k_processed.h5ad')
+        q = sc.datasets.pbmc3k_processed()
         gs = 'data/cibersort_lm22.gmt' # 'data/gene_set_test.gmt' #'data/cibersort_lm22.gmt'  #
         print("computing knn...")
         sc.pp.neighbors(q, n_neighbors=32)

--- a/gssnng/test/ssgsea_test.py
+++ b/gssnng/test/ssgsea_test.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         import time
 
         print("reading data")
-        q = sc.read_h5ad('data/pbmc3k_processed.h5ad')
+        q = sc.datasets.pbmc3k_processed()
 
         print("computing neighborhood")
         sc.pp.neighbors(q, n_neighbors=64)

--- a/notebooks/gssnng_quick_start.ipynb
+++ b/notebooks/gssnng_quick_start.ipynb
@@ -1,467 +1,454 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Jg_2JMjROflp"
-      },
-      "source": [
-        "# gssnng\n",
-        "Gene Set Scoring on the Nearest Neighbor Graph (gssnng) for Single Cell RNA-seq (scRNA-seq)\n",
-        "Works with AnnData objects stored as h5ad files. Takes values from adata.X.\n",
-        "\n",
-        "The method works by sampling nearest neighbors for each cell, creating a mini-pseudobulk expression profile, and performing single sample gene set scoring.  This gives each cell a score and preserves gradients across clusters. \n",
-        "\n",
-        "https://github.com/Gibbsdavidl/gssnng\n",
-        "\n",
-        "Notebook author: David L Gibbs (david.gibbs@isbscience.org)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "d-HTjuix9Qhg"
-      },
-      "outputs": [],
-      "source": [
-        "# first let's install the package from github\n",
-        "# and clone the repo for the example data\n",
-        "!pip install git+https://github.com/Gibbsdavidl/gssnng\n",
-        "!git clone https://github.com/Gibbsdavidl/gssnng"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "tQGZxmA-9iPH"
-      },
-      "outputs": [],
-      "source": [
-        "from gssnng import score_cells\n",
-        "import scanpy as sc\n",
-        "import matplotlib\n",
-        "%matplotlib inline"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "GSv5ru60Oflt"
-      },
-      "outputs": [],
-      "source": [
-        "## !! set up for google colab notebook !! ##\n",
-        "# these file paths point to the cloned repo from above #\n",
-        "anndata_file = '/content/gssnng/gssnng/test/data/pbmc3k_processed.h5ad'\n",
-        "gene_set_file = '/content/gssnng/gssnng/test/data/cibersort_lm22.gmt'\n",
-        "\n",
-        "# ! Note the direction labels on the gene set names ! #\n",
-        "gene_set_names = ['B.cells.naive.up', 'B.cells.memory.up', 'Plasma.cells.up', 'T.cells.CD8.up', 'T.cells.CD4.naive.up', 'T.cells.CD4.memory.resting.up', 'T.cells.CD4.memory.activated.up', 'T.cells.follicular.helper.up', 'T.cells.regulatory..Tregs.up', 'T.cells.gamma.delta.up', 'NK.cells.resting.up', 'NK.cells.activated.up', 'Monocytes.up', 'Macrophages.M0.up', 'Macrophages.M1.up', 'Macrophages.M2.up', 'Dendritic.cells.resting.up', 'Dendritic.cells.activated.up', 'Mast.cells.resting.up', 'Mast.cells.activated.up', 'Eosinophils.up', 'Neutrophils.up']"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Pk_AE0sp9zCm"
-      },
-      "outputs": [],
-      "source": [
-        "# read in the 10x genomics example data set, same as used in the scanpy tuts\n",
-        "q = sc.read_h5ad(anndata_file)\n",
-        "\n",
-        "# recompute the nearest neighbor graph to give plenty of neighbors to each cell\n",
-        "sc.pp.neighbors(q, n_neighbors=32)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1BIB2JT7-Rgz"
-      },
-      "outputs": [],
-      "source": [
-        "# Then we'll produce a gene set score, for each cell, for each gene set in the .gmt file.\n",
-        "# Neighbors are sampled within the groupby parameter. Groups run in parallel, set cores parameter as appropriate.\n",
-        "\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"singscore\",\n",
-        "        method_params={'normalization':'theoretical'},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=True,\n",
-        "        cores=6\n",
-        "    )\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rJCfi_iSOflv"
-      },
-      "outputs": [],
-      "source": [
-        "# each gene set is saved as a column in the AnnData.obs data.frame\n",
-        "q.obs"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "OJDK-T0ZDgKu"
-      },
-      "outputs": [],
-      "source": [
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "UZOMSu7QOflw"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "###########  THE TOUR OF METHODS #################\n",
-        "\n",
-        "---"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "JBWCNf-GOflx"
-      },
-      "outputs": [],
-      "source": [
-        "### RANK BIASED OVERLAP ###\n",
-        "### https://dl.acm.org/doi/10.1145/1852102.1852106\n",
-        "\n",
-        "# del the previous scores\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "# rescore\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"rank_biased_overlap\",\n",
-        "        method_params={'rbo_depth':50},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=True,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "eDcYlQJpOflx"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "BkBZxt5GOfly"
-      },
-      "outputs": [],
-      "source": [
-        "### MEAN Z SCORES COUNTS ###\n",
-        "### average of gene-wise Z scores\n",
-        "\n",
-        "# del the previous scores\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "# rescore\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"mean_z\",\n",
-        "        method_params={},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=False,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "nARM-2JcOflz"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "kx5gCsW_Oflz"
-      },
-      "outputs": [],
-      "source": [
-        "### MEDIAN RANKS ###\n",
-        "\n",
-        "# del the previous scores\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "# rescore\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"median_score\",\n",
-        "        method_params={},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=True,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "o2WEBDLiOfl0"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hDOrgFjYOfl0"
-      },
-      "outputs": [],
-      "source": [
-        "# ROBUST STANDARDIZED COUNTS\n",
-        "\n",
-        "# del the previous scores\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "# rescore\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"robust_std\",\n",
-        "        method_params={},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=False,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "jiwTYrEmOfl1"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2Z3UebOfOfl1"
-      },
-      "outputs": [],
-      "source": [
-        "### AVERAGE COUNTS ###\n",
-        "\n",
-        "# del the previous scores\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"average_score\",\n",
-        "        method_params={},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=True,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CCQqEcTnOfl1"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "d-Krc2w4Ofl1"
-      },
-      "outputs": [],
-      "source": [
-        "### SUMMED UP ###\n",
-        "\n",
-        "# del the previous scores\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "# rescore\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"summed_up\",\n",
-        "        method_params={},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=True,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CHc88MEiOfl2"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1N1Xdo8lOfl2"
-      },
-      "outputs": [],
-      "source": [
-        "### experimental!! ###\n",
-        "\n",
-        "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
-        "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
-        "\n",
-        "# rescore\n",
-        "score_cells.with_gene_sets(\n",
-        "        adata=q,\n",
-        "        gene_set_file=gene_set_file,\n",
-        "        groupby=\"louvain\",\n",
-        "        smooth_mode='connectivity',\n",
-        "        recompute_neighbors=0,\n",
-        "        score_method=\"ssgsea\",\n",
-        "        method_params={'omega':4},\n",
-        "        samp_neighbors=29,\n",
-        "        ranked=True,\n",
-        "        cores=6\n",
-        "    )\n",
-        "\n",
-        "# let's visualize the scores\n",
-        "# There appears to be a bug with showing color bar on google colab... \n",
-        "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "gssnng_quick_start.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.10"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Jg_2JMjROflp"
+   },
+   "source": [
+    "# gssnng\n",
+    "Gene Set Scoring on the Nearest Neighbor Graph (gssnng) for Single Cell RNA-seq (scRNA-seq)\n",
+    "Works with AnnData objects stored as h5ad files. Takes values from adata.X.\n",
+    "\n",
+    "The method works by sampling nearest neighbors for each cell, creating a mini-pseudobulk expression profile, and performing single sample gene set scoring.  This gives each cell a score and preserves gradients across clusters. \n",
+    "\n",
+    "https://github.com/Gibbsdavidl/gssnng\n",
+    "\n",
+    "Notebook author: David L Gibbs (david.gibbs@isbscience.org)"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d-HTjuix9Qhg"
+   },
+   "outputs": [],
+   "source": [
+    "# first let's install the package from github\n",
+    "# and clone the repo for the example data\n",
+    "!pip install git+https://github.com/Gibbsdavidl/gssnng\n",
+    "!git clone https://github.com/Gibbsdavidl/gssnng"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "tQGZxmA-9iPH"
+   },
+   "outputs": [],
+   "source": [
+    "from gssnng import score_cells\n",
+    "import scanpy as sc\n",
+    "import matplotlib\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "GSv5ru60Oflt"
+   },
+   "outputs": [],
+   "source": [
+    "## !! set up for google colab notebook !! ##\n",
+    "# these file paths point to the cloned repo from above #\n",
+    "gene_set_file = '/content/gssnng/gssnng/test/data/cibersort_lm22.gmt'\n",
+    "\n",
+    "# ! Note the direction labels on the gene set names ! #\n",
+    "gene_set_names = ['B.cells.naive.up', 'B.cells.memory.up', 'Plasma.cells.up', 'T.cells.CD8.up', 'T.cells.CD4.naive.up', 'T.cells.CD4.memory.resting.up', 'T.cells.CD4.memory.activated.up', 'T.cells.follicular.helper.up', 'T.cells.regulatory..Tregs.up', 'T.cells.gamma.delta.up', 'NK.cells.resting.up', 'NK.cells.activated.up', 'Monocytes.up', 'Macrophages.M0.up', 'Macrophages.M1.up', 'Macrophages.M2.up', 'Dendritic.cells.resting.up', 'Dendritic.cells.activated.up', 'Mast.cells.resting.up', 'Mast.cells.activated.up', 'Eosinophils.up', 'Neutrophils.up']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Pk_AE0sp9zCm"
+   },
+   "outputs": [],
+   "source": [
+    "# read in the 10x genomics example data set, same as used in the scanpy tuts\n",
+    "q = sc.datasets.pbmc3k_processed()\n",
+    "\n",
+    "# recompute the nearest neighbor graph to give plenty of neighbors to each cell\n",
+    "sc.pp.neighbors(q, n_neighbors=32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1BIB2JT7-Rgz"
+   },
+   "outputs": [],
+   "source": [
+    "# Then we'll produce a gene set score, for each cell, for each gene set in the .gmt file.\n",
+    "# Neighbors are sampled within the groupby parameter. Groups run in parallel, set cores parameter as appropriate.\n",
+    "\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"singscore\",\n",
+    "        method_params={'normalization':'theoretical'},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=True,\n",
+    "        cores=6\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rJCfi_iSOflv"
+   },
+   "outputs": [],
+   "source": [
+    "# each gene set is saved as a column in the AnnData.obs data.frame\n",
+    "q.obs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "OJDK-T0ZDgKu"
+   },
+   "outputs": [],
+   "source": [
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UZOMSu7QOflw"
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "###########  THE TOUR OF METHODS #################\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JBWCNf-GOflx"
+   },
+   "outputs": [],
+   "source": [
+    "### RANK BIASED OVERLAP ###\n",
+    "### https://dl.acm.org/doi/10.1145/1852102.1852106\n",
+    "\n",
+    "# del the previous scores\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "# rescore\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"rank_biased_overlap\",\n",
+    "        method_params={'rbo_depth':50},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=True,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eDcYlQJpOflx"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "BkBZxt5GOfly"
+   },
+   "outputs": [],
+   "source": [
+    "### MEAN Z SCORES COUNTS ###\n",
+    "### average of gene-wise Z scores\n",
+    "\n",
+    "# del the previous scores\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "# rescore\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"mean_z\",\n",
+    "        method_params={},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=False,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nARM-2JcOflz"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kx5gCsW_Oflz"
+   },
+   "outputs": [],
+   "source": [
+    "### MEDIAN RANKS ###\n",
+    "\n",
+    "# del the previous scores\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "# rescore\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"median_score\",\n",
+    "        method_params={},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=True,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "o2WEBDLiOfl0"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hDOrgFjYOfl0"
+   },
+   "outputs": [],
+   "source": [
+    "# ROBUST STANDARDIZED COUNTS\n",
+    "\n",
+    "# del the previous scores\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "# rescore\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"robust_std\",\n",
+    "        method_params={},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=False,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jiwTYrEmOfl1"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2Z3UebOfOfl1"
+   },
+   "outputs": [],
+   "source": [
+    "### AVERAGE COUNTS ###\n",
+    "\n",
+    "# del the previous scores\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"average_score\",\n",
+    "        method_params={},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=True,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CCQqEcTnOfl1"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d-Krc2w4Ofl1"
+   },
+   "outputs": [],
+   "source": [
+    "### SUMMED UP ###\n",
+    "\n",
+    "# del the previous scores\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "# rescore\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"summed_up\",\n",
+    "        method_params={},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=True,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CHc88MEiOfl2"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1N1Xdo8lOfl2"
+   },
+   "outputs": [],
+   "source": [
+    "### experimental!! ###\n",
+    "\n",
+    "q.obs.drop(gene_set_names, axis=1, inplace=True)\n",
+    "q.obs.drop('gssnng_groupby', axis=1, inplace=True)\n",
+    "\n",
+    "# rescore\n",
+    "score_cells.with_gene_sets(\n",
+    "        adata=q,\n",
+    "        gene_set_file=gene_set_file,\n",
+    "        groupby=\"louvain\",\n",
+    "        smooth_mode='connectivity',\n",
+    "        recompute_neighbors=0,\n",
+    "        score_method=\"ssgsea\",\n",
+    "        method_params={'omega':4},\n",
+    "        samp_neighbors=29,\n",
+    "        ranked=True,\n",
+    "        cores=6\n",
+    "    )\n",
+    "\n",
+    "# let's visualize the scores\n",
+    "# There appears to be a bug with showing color bar on google colab... \n",
+    "sc.pl.umap(q, color=['T.cells.CD8.up','B.cells.naive.up','louvain'], wspace=0.1, colorbar_loc=None) \n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "gssnng_quick_start.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Removed the dependency on `gssnng/test/data/pbmc3k_processed.h5ad` via `sc.datasets.pbmc3k_processed()` (downloads on demand).
Less trouble with packaging, smaller package.